### PR TITLE
chore(.github): Update link to CONTRIBUTE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ _Put an `x` in the boxes that apply_
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is a reminder of what we are going to look for before merging your code._
 
-- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guide
+- [ ] I have read the [CONTRIBUTING](https://github.com/michael-ciniawsky/postcss-load-config/blob/master/CONTRIBUTING.md) guide
 - [ ] Lint and unit tests pass with my changes
 - [ ] I have added tests that prove my fix is effective/works
 - [ ] I have added necessary documentation (if appropriate)


### PR DESCRIPTION
## Proposed changes

When one creates a PR from the template, link to CONTRIBUTE.md is invalid, because it's relative.
Let's make it reachable from any place by providing full URL.

## Types of changes

What types of changes does your code introduce
_Put an `x` in the boxes that apply_

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature which changes existing functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guide
- n/a Lint and unit tests pass with my changes
- n/a I have added tests that prove my fix is effective/works
- n/a I have added necessary documentation (if appropriate)
- n/a  Any dependent changes are merged and published in downstream modules

### Reviewers: @michael-ciniawsky

