### PR TITLE
Allow file extensions for .postcssrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,20 @@ App
 
 ### `.postcssrc`
 
-Create a **`.postcssrc`** file.
+Create a **`.postcssrc`** file in JSON or YAML format.
+
+It's also allowed to use extensions (**`.postcssrc.json`** or **`.postcssrc.yaml`**). That could help your text editor to properly interpret the file.
 
 ```
 App
   |– client
   |– public
   |
-  |-.postcssrc
+  |- (.postcssrc|.postcssrc.json|.postcssrc.yaml)
   |- package.json
 ```
 
+JSON:
 ```json
 {
   "parser": "sugarss",
@@ -79,20 +82,43 @@ App
   }
 }
 ```
+YAML:
+```yaml
+parser: sugarss
+map: false
+from: "/path/to/src.sss"
+to: "/path/to/dest.css"
+plugins:
+  postcss-plugin: {}
+```
 
-### `postcss.config.js`
+### `postcss.config.js` or `.postcssrc.js`
 
-Create a **`postcss.config.js`** file.
+You may need some JavaScript logic to generate your config. For this case you can use a file named **`postcss.config.js`** or **`.postcssrc.js`**.
 
 ```
 App
   |– client
   |– public
   |
-  |- postcss.config.js
+  |- (postcss.config.js|.postcssrc.js)
   |- package.json
 ```
 
+You can simply export the config as a plain object:
+```js
+module.exports = {
+  parser: 'sugarss',
+  map: false,
+  from: '/path/to/src.sss',
+  to: '/path/to/dest.css',
+  plugins: {
+    'postcss-plugin': {}
+  }
+}
+```
+
+Or export a function that returns the config (more about param `ctx` below):
 ```js
 module.exports = (ctx) => ({
   parser: ctx.parser ? 'sugarss' : false,
@@ -206,7 +232,7 @@ Plugin **order** is determined by declaration in the plugins section.
 
 <h2 align="center">Context</h2>
 
-When using a function `(postcss.config.js)`, it is possible to pass context to `postcss-load-config`, which will be evaluated while loading your config. By default `ctx.env (process.env.NODE_ENV)` and `ctx.cwd (process.cwd())` are available.
+When using a function (`postcss.config.js` or `.postcssrc.js`), it is possible to pass context to `postcss-load-config`, which will be evaluated while loading your config. By default `ctx.env (process.env.NODE_ENV)` and `ctx.cwd (process.cwd())` are available.
 
 <h2 align="center">Examples</h2>
 

--- a/README.md
+++ b/README.md
@@ -370,6 +370,12 @@ module.exports = (env) => ({
       <br />
       <a href="https://github.com/pcgilday">Patrick Gilday</a>
     </td>
+    <td align="center">
+      <img width="150" height="150"
+        src="https://avatars.githubusercontent.com/u/5603632?v=3&s=150">
+      <br />
+      <a href="https://github.com/daltones">Dalton Santos</a>
+    </td>
   </tr>
   <tbody>
 </table>

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function postcssrc (ctx, path, options) {
 
   path = path ? resolve(path) : process.cwd()
 
-  options = assign({}, options)
+  options = assign({rcExtensions: true}, options)
 
   if (!ctx.env) process.env.NODE_ENV = 'development'
 


### PR DESCRIPTION
## Proposed changes

This PR introduces support for config files `.postcssrc.json` or `.postcssrc.yaml` (alternatives for `.postcssrc`) and `.postcssrc.js` (alternative for `postcss.config.js`). This is done by just enabling `cosmiconfig`'s option `rcExtensions`.

YAML format seems like news, but in fact it was already supported in `.postcssrc` once it's a `cosmiconfig` default behavior.

Extensions `.json` and `.yaml` are very helpful for text editors to give the right syntax highlighting.

`.postcssrc.js` offers a standard base name and is preferred in cases when it's interesting to this file be a dot-file (eg: ESLint ignores dot-files by default and you don't want `.postcssrc.js` to be linted along with all other source js files).

This feature makes `postcss-load-config` consistent with other `cosmiconfig` based projects like [ESLint](https://github.com/eslint/eslint) and [Stylelint](https://github.com/stylelint/stylelint).

## Types of changes

- [ ] Bug (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature which changes existing functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/michael-ciniawsky/postcss-load-config/blob/master/CONTRIBUTING.md) guide
- [X] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
- [X] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules

## Further comments

I saw that there's some separated tests for different config filenames. But I didn't feel like it's necessary to add more tests since we're just using `cosmiconfig` in a trivial way. Resolving of various config files are already well tested by `cosmiconfig` itself.

### Reviewers: @michael-ciniawsky, @ertrzyiks