### PR TITLE
fix(index): set `options.argv` to false (`cosmiconfig`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,12 @@ module.exports = (env) => ({
       <br />
       <a href="https://github.com/daltones">Dalton Santos</a>
     </td>
+    <td align="center">
+      <img width="150" height="150"
+        src="https://avatars.githubusercontent.com/u/22251956?v=3&s=150">
+      <br />
+      <a href="https://github.com/sudo-suhas">Suhas Karanth</a>
+    </td>
   </tr>
   <tbody>
 </table>

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function postcssrc (ctx, path, options) {
 
   path = path ? resolve(path) : process.cwd()
 
-  options = assign({ rcExtensions: true }, options)
+  options = assign({ rcExtensions: true, argv: false }, options)
 
   if (!ctx.env) process.env.NODE_ENV = 'development'
 


### PR DESCRIPTION
## Proposed changes

This fixes an issue with invocation of cosmiconfig while being used with webpack(through postcss-loader). By default, cosmiconfig looks for `--config` flag value. Relevant docs - [davidtheclark/cosmiconfig#argv](https://github.com/davidtheclark/cosmiconfig#argv). This conflicts with the webpack flag. Setting `argv` to `false` resolves the issue.

Related issue - davidtheclark/cosmiconfig#77

## Types of changes

Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/michael-ciniawsky/postcss-load-config/blob/master/CONTRIBUTING.md) guide
- [x] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules

## Further comments

I have not added any tests for this change as postcss-loader is probably the more appropriate place to have the test in.

### Reviewers: @michael-ciniawsky, @ertrzyiks
