### PR TITLE
ci(travis): drop support for `node =< v4.0.0`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - 'stable'
   - 'lts/*'
   - 6
-  - 4
 
 script: npm run lint && npm t
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "cssnano": "^4.0.0",
     "del-cli": "^1.0.0",
-    "jest": "^22.0.0",
+    "jest": "^23.6.0",
     "jsdoc-to-markdown": "^4.0.0",
     "postcss": "^7.0.0",
     "postcss-import": "^11.0.0",


### PR DESCRIPTION
The latest Jest doesn't support Node.js 4 so it makes sense to drop it here as well.

See failing test on Travis CI: https://travis-ci.org/michael-ciniawsky/postcss-load-config/jobs/443113074#L583