### PR TITLE
feat(src/index): support synchronous config loading (`rc.sync`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ module.exports = (ctx) => ({
 }
 ```
 
+### `Async`
+
 ```js
 const { readFileSync } = require('fs')
 
@@ -337,6 +339,21 @@ postcssrc(ctx).then(({ plugins, options }) => {
     .process(css, options)
     .then((result) => console.log(result.css))
 })
+```
+
+### `Sync`
+
+```js
+const { readFileSync } = require('fs')
+
+const postcss = require('postcss')
+const postcssrc = require('postcss-load-config')
+
+const css = readFileSync('index.sss', 'utf8')
+
+const ctx = { parser: true, map: 'inline' }
+
+const { plugins, options } = postcssrc.sync(ctx)
 ```
 
 <div align="center">

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release": "standard-version"
   },
   "dependencies": {
-    "cosmiconfig": "^4.0.0",
+    "cosmiconfig": "^5.0.0",
     "import-cwd": "^2.0.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,61 @@ const loadOptions = require('./options.js')
 const loadPlugins = require('./plugins.js')
 
 /**
+ * Process the result from cosmiconfig
+ *
+ * @param  {Object} ctx Config Context
+ * @param  {Object} result Cosmiconfig result
+ *
+ * @return {Object} PostCSS Config
+ */
+const processResult = (ctx, result) => {
+  let file = result.filepath || ''
+  let config = result.config || {}
+
+  if (typeof config === 'function') {
+    config = config(ctx)
+  } else {
+    config = Object.assign({}, config, ctx)
+  }
+
+  if (!config.plugins) {
+    config.plugins = []
+  }
+
+  return {
+    plugins: loadPlugins(config, file),
+    options: loadOptions(config, file),
+    file: file
+  }
+}
+
+/**
+ * Builds the Config Context
+ *
+ * @param  {Object} ctx Config Context
+ *
+ * @return {Object} Config Context
+ */
+const createContext = (ctx) => {
+  /**
+   * @type {Object}
+   *
+   * @prop {String} cwd=process.cwd() Config search start location
+   * @prop {String} env=process.env.NODE_ENV Config Enviroment, will be set to `development` by `postcss-load-config` if `process.env.NODE_ENV` is `undefined`
+   */
+  ctx = Object.assign({
+    cwd: process.cwd(),
+    env: process.env.NODE_ENV
+  }, ctx)
+
+  if (!ctx.env) {
+    process.env.NODE_ENV = 'development'
+  }
+
+  return ctx
+}
+
+/**
  * Load Config
  *
  * @method rc
@@ -20,33 +75,14 @@ const loadPlugins = require('./plugins.js')
  */
 const rc = (ctx, path, options) => {
   /**
-   * @type {Object}
-   *
-   * @prop {String} cwd=process.cwd() Config search start location
-   * @prop {String} env=process.env.NODE_ENV Config Enviroment, will be set to `development` by `postcss-load-config` if `process.env.NODE_ENV` is `undefined`
+   * @type {Object} The full Config Context
    */
-  ctx = Object.assign({
-    cwd: process.cwd(),
-    env: process.env.NODE_ENV
-  }, ctx)
+  ctx = createContext(ctx)
+
   /**
    * @type {String} `process.cwd()`
-   *
    */
   path = path ? resolve(path) : process.cwd()
-
-  /**
-   * @type {Object}
-   *
-   * @prop {Boolean} rcExtensions=true
-   */
-  options = Object.assign({
-    rcExtensions: true
-  }, options)
-
-  if (!ctx.env) {
-    process.env.NODE_ENV = 'development'
-  }
 
   return config('postcss', options)
     .search(path)
@@ -55,25 +91,28 @@ const rc = (ctx, path, options) => {
         throw new Error(`No PostCSS Config found in: ${path}`)
       }
 
-      let file = result.filepath || ''
-      let config = result.config || {}
-
-      if (typeof config === 'function') {
-        config = config(ctx)
-      } else {
-        config = Object.assign({}, config, ctx)
-      }
-
-      if (!config.plugins) {
-        config.plugins = []
-      }
-
-      return {
-        plugins: loadPlugins(config, file),
-        options: loadOptions(config, file),
-        file: file
-      }
+      return processResult(ctx, result)
     })
+}
+
+rc.sync = (ctx, path, options) => {
+  /**
+   * @type {Object} The full Config Context
+   */
+  ctx = createContext(ctx)
+
+  /**
+   * @type {String} `process.cwd()`
+   */
+  path = path ? resolve(path) : process.cwd()
+
+  const result = config('postcss', options).searchSync(path)
+
+  if (!result) {
+    throw new Error(`No PostCSS Config found in: ${path}`)
+  }
+
+  return processResult(ctx, result)
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const rc = (ctx, path, options) => {
   }
 
   return config('postcss', options)
-    .load(path)
+    .search(path)
     .then((result) => {
       if (!result) {
         throw new Error(`No PostCSS Config found in: ${path}`)

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -14,22 +14,18 @@ const req = require('import-cwd')
  * @return {Function} PostCSS Plugin
  */
 const load = (plugin, options, file) => {
-  if (
-    options === null ||
-    options === undefined ||
-    Object.keys(options).length === 0
-  ) {
-    try {
+  try {
+    if (
+      options === null ||
+      options === undefined ||
+      Object.keys(options).length === 0
+    ) {
       return req(plugin)
-    } catch (err) {
-      throw new Error(`Loading PostCSS Plugin failed: ${err.message}\n\n(@${file})`)
-    }
-  } else {
-    try {
+    } else {
       return req(plugin)(options)
-    } catch (err) {
-      throw new Error(`Loading PostCSS Plugin failed: ${err.message}\n\n(@${file})`)
     }
+  } catch (err) {
+    throw new Error(`Loading PostCSS Plugin failed: ${err.message}\n\n(@${file})`)
   }
 }
 

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -10,6 +10,16 @@ test('Loading Config - {Error}', () => {
   })
 })
 
+test('Loading Config - Sync - {Error}', () => {
+  try {
+    postcssrc.sync({}, 'test/err')
+  } catch (err) {
+    expect(err.message).toMatch(
+      /^No PostCSS Config found in: (.*)$/
+    )
+  }
+})
+
 describe('Loading Plugins - {Error}', () => {
   test('Plugin - {Type} - Invalid', () => {
     return postcssrc({}, 'test/err/plugins').catch((err) => {
@@ -52,6 +62,58 @@ describe('Loading Plugins - {Error}', () => {
   })
 })
 
+describe('Loading Plugins - Sync - {Error}', () => {
+  test('Plugin - {Type} - Invalid', () => {
+    try {
+      postcssrc.sync({}, 'test/err/plugins')
+    } catch (err) {
+      expect(err.message).toMatch(
+        /^Invalid PostCSS Plugin found at: (.*)\n\n\(@.*\)$/
+      )
+    }
+  })
+
+  test('Plugin - {Object}', () => {
+    try {
+      postcssrc.sync({}, 'test/err/plugins/object')
+    } catch (err) {
+      expect(err.message).toMatch(
+        /^Loading PostCSS Plugin failed: (.*)\n\n\(@.*\)$/
+      )
+    }
+  })
+
+  test('Plugin - {Object} - Options', () => {
+    try {
+      postcssrc.sync({}, 'test/err/plugins/object/options')
+    } catch (err) {
+      expect(err.message).toMatch(
+        /^Loading PostCSS Plugin failed: (.*)\n\n\(@.*\)$/
+      )
+    }
+  })
+
+  test('Plugin - {Array}', () => {
+    try {
+      postcssrc.sync({}, 'test/err/plugins/array')
+    } catch (err) {
+      expect(err.message).toMatch(
+        /^Cannot find (.*)$/
+      )
+    }
+  })
+
+  test('Plugin - {Array} - Options', () => {
+    try {
+      postcssrc.sync({}, 'test/err/plugins/array/options')
+    } catch (err) {
+      expect(err.message).toMatch(
+        /^Cannot find (.*)$/
+      )
+    }
+  })
+})
+
 describe('Loading Options - {Error}', () => {
   test('Parser - {String}', () => {
     return postcssrc({}, 'test/err/options/parser').catch((err) => {
@@ -75,5 +137,37 @@ describe('Loading Options - {Error}', () => {
         /^Loading PostCSS Stringifier failed: (.*)\n\n\(@.*\)$/
       )
     })
+  })
+})
+
+describe('Loading Options - Sync - {Error}', () => {
+  test('Parser - {String}', () => {
+    try {
+      postcssrc.sync({}, 'test/err/options/parser')
+    } catch (err) {
+      expect(err.message).toMatch(
+        /^Loading PostCSS Parser failed: (.*)\n\n\(@.*\)$/
+      )
+    }
+  })
+
+  test('Syntax - {String}', () => {
+    try {
+      postcssrc.sync({}, 'test/err/options/syntax')
+    } catch (err) {
+      expect(err.message).toMatch(
+        /^Loading PostCSS Syntax failed: (.*)\n\n\(@.*\)$/
+      )
+    }
+  })
+
+  test('Stringifier - {String}', () => {
+    try {
+      postcssrc.sync({}, 'test/err/options/stringifier')
+    } catch (err) {
+      expect(err.message).toMatch(
+        /^Loading PostCSS Stringifier failed: (.*)\n\n\(@.*\)$/
+      )
+    }
   })
 })

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -32,7 +32,7 @@ describe('Loading Plugins - {Error}', () => {
   test('Plugin - {Object}', () => {
     return postcssrc({}, 'test/err/plugins/object').catch((err) => {
       expect(err.message).toMatch(
-        /^Loading PostCSS Plugin failed: (.*)\n\n\(@.*\)$/
+        /^Loading PostCSS Plugin failed: .*$/m
       )
     })
   })
@@ -40,7 +40,7 @@ describe('Loading Plugins - {Error}', () => {
   test('Plugin - {Object} - Options', () => {
     return postcssrc({}, 'test/err/plugins/object/options').catch((err) => {
       expect(err.message).toMatch(
-        /^Loading PostCSS Plugin failed: (.*)\n\n\(@.*\)$/
+        /^Loading PostCSS Plugin failed: .*$/m
       )
     })
   })
@@ -78,7 +78,7 @@ describe('Loading Plugins - Sync - {Error}', () => {
       postcssrc.sync({}, 'test/err/plugins/object')
     } catch (err) {
       expect(err.message).toMatch(
-        /^Loading PostCSS Plugin failed: (.*)\n\n\(@.*\)$/
+        /^Loading PostCSS Plugin failed: .*$/m
       )
     }
   })
@@ -88,7 +88,7 @@ describe('Loading Plugins - Sync - {Error}', () => {
       postcssrc.sync({}, 'test/err/plugins/object/options')
     } catch (err) {
       expect(err.message).toMatch(
-        /^Loading PostCSS Plugin failed: (.*)\n\n\(@.*\)$/
+        /^Loading PostCSS Plugin failed: .*$/m
       )
     }
   })
@@ -118,7 +118,7 @@ describe('Loading Options - {Error}', () => {
   test('Parser - {String}', () => {
     return postcssrc({}, 'test/err/options/parser').catch((err) => {
       expect(err.message).toMatch(
-        /^Loading PostCSS Parser failed: (.*)\n\n\(@.*\)$/
+        /^Loading PostCSS Parser failed: .*$/m
       )
     })
   })
@@ -126,7 +126,7 @@ describe('Loading Options - {Error}', () => {
   test('Syntax - {String}', () => {
     return postcssrc({}, 'test/err/options/syntax').catch((err) => {
       expect(err.message).toMatch(
-        /^Loading PostCSS Syntax failed: (.*)\n\n\(@.*\)$/
+        /^Loading PostCSS Syntax failed: .*$/m
       )
     })
   })
@@ -134,7 +134,7 @@ describe('Loading Options - {Error}', () => {
   test('Stringifier - {String}', () => {
     return postcssrc({}, 'test/err/options/stringifier').catch((err) => {
       expect(err.message).toMatch(
-        /^Loading PostCSS Stringifier failed: (.*)\n\n\(@.*\)$/
+        /^Loading PostCSS Stringifier failed: .*$/m
       )
     })
   })
@@ -146,7 +146,7 @@ describe('Loading Options - Sync - {Error}', () => {
       postcssrc.sync({}, 'test/err/options/parser')
     } catch (err) {
       expect(err.message).toMatch(
-        /^Loading PostCSS Parser failed: (.*)\n\n\(@.*\)$/
+        /^Loading PostCSS Parser failed: .*$/m
       )
     }
   })
@@ -156,7 +156,7 @@ describe('Loading Options - Sync - {Error}', () => {
       postcssrc.sync({}, 'test/err/options/syntax')
     } catch (err) {
       expect(err.message).toMatch(
-        /^Loading PostCSS Syntax failed: (.*)\n\n\(@.*\)$/
+        /^Loading PostCSS Syntax failed: .*$/m
       )
     }
   })
@@ -166,7 +166,7 @@ describe('Loading Options - Sync - {Error}', () => {
       postcssrc.sync({}, 'test/err/options/stringifier')
     } catch (err) {
       expect(err.message).toMatch(
-        /^Loading PostCSS Stringifier failed: (.*)\n\n\(@.*\)$/
+        /^Loading PostCSS Stringifier failed: .*$/m
       )
     }
   })

--- a/test/js.test.js
+++ b/test/js.test.js
@@ -7,13 +7,13 @@ const postcssrc = require('../src/index.js')
 
 const { fixture, expected } = require('./utils.js')
 
-test('postcss.config.js - {Object} - Load Config', () => {
+describe('postcss.config.js - {Object} - Load Config', () => {
   const ctx = {
     parser: true,
     syntax: true
   }
 
-  return postcssrc(ctx, 'test/js/object').then((config) => {
+  const expected = (config) => {
     expect(config.options.parser).toEqual(require('sugarss'))
     expect(config.options.syntax).toEqual(require('sugarss'))
     expect(config.options.map).toEqual(false)
@@ -26,6 +26,16 @@ test('postcss.config.js - {Object} - Load Config', () => {
 
     expect(config.file)
       .toEqual(path.resolve('test/js/object', 'postcss.config.js'))
+  }
+
+  test('Async', () => {
+    return postcssrc(ctx, 'test/js/object').then(expected)
+  })
+
+  test('Sync', () => {
+    const config = postcssrc.sync(ctx, 'test/js/object')
+
+    expected(config)
   })
 })
 
@@ -60,13 +70,13 @@ test('postcss.config.js - {Object} - Process SSS', () => {
   })
 })
 
-test('postcss.config.js - {Array} - Load Config', () => {
+describe('postcss.config.js - {Array} - Load Config', () => {
   const ctx = {
     parser: true,
     syntax: true
   }
 
-  return postcssrc(ctx, 'test/js/array').then((config) => {
+  const expected = (config) => {
     expect(config.options.parser).toEqual(require('sugarss'))
     expect(config.options.syntax).toEqual(require('sugarss'))
     expect(config.options.map).toEqual(false)
@@ -79,6 +89,16 @@ test('postcss.config.js - {Array} - Load Config', () => {
 
     expect(config.file)
       .toEqual(path.resolve('test/js/array', 'postcss.config.js'))
+  }
+
+  test('Async', () => {
+    return postcssrc(ctx, 'test/js/array').then(expected)
+  })
+
+  test('Sync', () => {
+    const config = postcssrc.sync(ctx, 'test/js/array')
+
+    expected(config)
   })
 })
 

--- a/test/pkg.test.js
+++ b/test/pkg.test.js
@@ -7,8 +7,8 @@ const postcssrc = require('../src/index.js')
 
 const { fixture, expected } = require('./utils.js')
 
-test('package.json - {Object} - Load Config', () => {
-  return postcssrc({}, 'test/pkg').then((config) => {
+describe('package.json - {Object} - Load Config', () => {
+  const expected = (config) => {
     expect(config.options.parser).toEqual(require('sugarss'))
     expect(config.options.syntax).toEqual(require('sugarss'))
     expect(config.options.map).toEqual(false)
@@ -21,6 +21,16 @@ test('package.json - {Object} - Load Config', () => {
 
     expect(config.file)
       .toEqual(path.resolve('test/pkg', 'package.json'))
+  }
+
+  test('Async', () => {
+    return postcssrc({}, 'test/pkg').then(expected)
+  })
+
+  test('Sync', () => {
+    const config = postcssrc.sync({}, 'test/pkg')
+
+    expected(config)
   })
 })
 

--- a/test/rc.test.js
+++ b/test/rc.test.js
@@ -7,8 +7,8 @@ const postcssrc = require('../src/index.js')
 
 const { fixture, expected } = require('./utils.js')
 
-test('.postcssrc - {Object} - Load Config', () => {
-  return postcssrc({}, 'test/rc').then((config) => {
+describe('.postcssrc - {Object} - Load Config', () => {
+  const expected = (config) => {
     expect(config.options.parser).toEqual(require('sugarss'))
     expect(config.options.syntax).toEqual(require('sugarss'))
     expect(config.options.map).toEqual(false)
@@ -21,6 +21,16 @@ test('.postcssrc - {Object} - Load Config', () => {
 
     expect(config.file)
       .toEqual(path.resolve('test/rc', '.postcssrc'))
+  }
+
+  test('Async', () => {
+    return postcssrc({}, 'test/rc').then(expected)
+  })
+
+  test('Sync', () => {
+    const config = postcssrc.sync({}, 'test/rc')
+
+    expected(config)
   })
 })
 


### PR DESCRIPTION
### `Notable Changes`

This PR adds support for a synchronous loading function, such as:

```js
const postcssrc = require("postcss-load-config")
const config = postcssrc.sync({})
```

I'm trying to write an eslint plugin, but eslint has no support for asynchronous plugins. I would love to use postcss-load-config, but I would need this support for that.

While I was in there, I also updated cosmiconfig to the latest version, which closes #184.

#### `Commit Message Summary (CHANGELOG)`

```
chore(package): update `cosmiconfig` v4.0.0...5.0.0
feat(src/index): support synchronous config loading (`rc.sync`)
```

### `Type`

- [x] Chore
- [x] Feature

### `SemVer`

- [x] Feature (:label: Minor)

### `Issues`

- Fixes #184 

### `Checklist`

- [x] Lint and unit tests pass with my changes
- [x] I have added tests that prove my fix is effective/works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes are merged and published in downstream modules
